### PR TITLE
Do not print the day next to each timer event

### DIFF
--- a/eq3.exp
+++ b/eq3.exp
@@ -683,7 +683,7 @@ proc printTimer {day} {
   }
   for {set event 1} {$event <= 7} {incr event} {
     set key "[lindex $day 0]_[lindex $event 0]"
-    append out "\t[lindex $DAYS $day], $thermostat("timer_start_$key") - $thermostat("timer_end_$key"):\t$thermostat("timer_temperature_$key")°C\n"
+    append out "\t$thermostat("timer_start_$key") - $thermostat("timer_end_$key"):\t$thermostat("timer_temperature_$key")°C\n"
    if {"24:00" == "$thermostat("timer_end_$key")"} {
       break
     }

--- a/eq3.exp
+++ b/eq3.exp
@@ -691,6 +691,38 @@ proc printTimer {day} {
   return $out
 }
 
+proc dumpTimer {day} {
+  global DAYS
+  global thermostat
+
+  set out "timer "
+  append out [string tolower [lindex $DAYS $day]]
+  append out " "
+  for {set event 1} {$event <= 7} {incr event} {
+    set key "[lindex $day 0]_[lindex $event 0]"
+    if {"00:00" == "$thermostat("timer_start_$key")"} {
+      append out "$thermostat("timer_temperature_$key") "
+      continue
+    }
+    if {"24:00" == "$thermostat("timer_end_$key")"} {
+      append out "$thermostat("timer_start_$key")"
+      break
+    }
+    append out "$thermostat("timer_start_$key") $thermostat("timer_temperature_$key") "
+  }
+
+  append out "\n"
+  return $out
+}
+
+proc dumpTimers {} {
+  set out ""
+  for {set day 0} {$day < 7} {incr day} {
+    append out [dumpTimer $day]
+  }
+  return $out
+}
+
 proc printTimers {} {
   global DAYS
 
@@ -1032,7 +1064,7 @@ proc doCommand {} {
     }
     ^timers$ {
       init $INIT(timer)
-      puts [printTimers]
+      puts [dumpTimers]
     }
     ^timer.* {
       set params [lindex $c 1]


### PR DESCRIPTION
The day is printed above and there seem to be no point in repeating that.

Signed-off-by: Łukasz Stelmach <stlman@poczta.fm>